### PR TITLE
Add/julia share

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: |
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
             /bin/bash Miniconda3-latest-Linux-x86_64.sh -b 
-            $HOME/miniconda3/bin/python -m pip install pyaml containershare==0.0.11
+            $HOME/miniconda3/bin/python -m pip install pyaml containershare==0.0.12
             cd $HOME/containershare/docs
             $HOME/miniconda3/bin/python ../tests/circle_urls.py $HOME/containershare/docs/_site
       - run:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Do you have a jupyter (or similar) notebook and want to quickly build and deploy
 
 ### General Docker
 If you have a general Docker container that is built from a Dockerfile in your repository, check out the
-[share-docker template](#) (available soon!)
+[share-docker template](https://www.github.com/vsoch/share-docker). As an example, this template is used to build [share-jupyter](https://www.github.com/vsoch/share-jupyter).
 
+Do you have another container template you'd like? [Let me know](https://www.github.com/vsoch/containershare/issues)!
 
 ### Step 2. Submit Metadata
 

--- a/docs/_library/julia-share.md
+++ b/docs/_library/julia-share.md
@@ -1,0 +1,12 @@
+---
+layout: null
+name:  "vanessa/julia-share"
+maintainer: "@vsoch"
+github: "https://www.github.com/vsoch/julia-share"
+docker: "https://hub.docker.com/r/vanessa/julia-share"
+web: "https://vsoch.github.io/julia-share"
+uid: "julia-share"
+tags:
+- julia
+- jupyter
+---


### PR DESCRIPTION
This PR will add the Julia Share container to the library. The container provides Julia+Jupyter and a few custom libraries - not fully tested yet on Sherlock but builds successfully on Docker Hub!